### PR TITLE
Fix operations ordering and unify Supabase client

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from 'react'
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
+import { Routes, Route, Navigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ThemeProvider } from './lib/theme'
 import { I18nextProvider } from 'react-i18next'
 import i18n from './lib/i18n'
-import { AuthProvider } from './contexts/AuthContext'
 import { ProtectedRoute } from './components/ProtectedRoute'
 import { AppLayout } from './components/layout/AppLayout'
 import { Login } from './pages/Login'
@@ -13,7 +12,6 @@ import { Operations } from './pages/Operations'
 import { Inventaire } from './pages/Inventaire'
 import { Mouvements } from './pages/Mouvements'
 import { Parametres } from './pages/Parametres'
-import { PageLoader } from './components/ui/LoadingSpinner'
 import { repository } from './lib/repositories'
 import './index.css'
 
@@ -143,8 +141,7 @@ function AppContent() {
 
   // Application principale avec routing
   return (
-    <Router>
-      <Routes>
+    <Routes>
         {/* Route publique de connexion */}
         <Route path="/login" element={<Login />} />
         
@@ -236,7 +233,6 @@ function AppContent() {
           }
         />
       </Routes>
-    </Router>
   )
 }
 
@@ -244,9 +240,7 @@ function App() {
   return (
     <I18nextProvider i18n={i18n}>
       <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
-        <AuthProvider>
-          <AppContent />
-        </AuthProvider>
+        <AppContent />
       </ThemeProvider>
     </I18nextProvider>
   )

--- a/src/lib/repositories/supabase.repository.ts
+++ b/src/lib/repositories/supabase.repository.ts
@@ -19,10 +19,10 @@ export class SupabaseRepository implements DataRepository {
 
     if (filtres) {
       if (filtres.date_debut) {
-        query = query.gte('date_operation', filtres.date_debut.toISOString());
+        query = query.gte('op_date', filtres.date_debut.toISOString());
       }
       if (filtres.date_fin) {
-        query = query.lte('date_operation', filtres.date_fin.toISOString());
+        query = query.lte('op_date', filtres.date_fin.toISOString());
       }
       if (filtres.produit) {
         query = query.ilike('produit', `%${filtres.produit}%`);
@@ -35,49 +35,62 @@ export class SupabaseRepository implements DataRepository {
       }
     }
 
-    const { data, error } = await query.order('date_operation', { ascending: false });
-    
+    const { data, error } = await query.order('op_date', { ascending: false });
+
     if (error) throw error;
-    
-    return (data || []).map(op => ({
-      ...op,
-      date_operation: new Date(op.date_operation)
-    }));
+
+    return (data || []).map(op => {
+      const { op_date, ...rest } = op as any;
+      return {
+        ...rest,
+        date_operation: new Date(op_date)
+      } as Operation;
+    });
   }
 
   async createOperation(operation: Omit<Operation, 'id'>): Promise<Operation> {
     if (!supabase) throw new Error('Supabase not initialized');
 
+    const { date_operation, ...rest } = operation;
+    const insertData = { ...rest, op_date: date_operation } as any;
+
     const { data, error } = await supabase
       .from('operations')
-      .insert([operation])
+      .insert([insertData])
       .select()
       .single();
 
     if (error) throw error;
-    
+
+    const { op_date, ...result } = data as any;
     return {
-      ...data,
-      date_operation: new Date(data.date_operation)
-    };
+      ...result,
+      date_operation: new Date(op_date)
+    } as Operation;
   }
 
   async updateOperation(id: string, operation: Partial<Operation>): Promise<Operation> {
     if (!supabase) throw new Error('Supabase not initialized');
 
+    const { date_operation, ...rest } = operation;
+    const updateData = date_operation
+      ? { ...rest, op_date: date_operation }
+      : rest;
+
     const { data, error } = await supabase
       .from('operations')
-      .update(operation)
+      .update(updateData)
       .eq('id', id)
       .select()
       .single();
 
     if (error) throw error;
-    
+
+    const { op_date, ...result } = data as any;
     return {
-      ...data,
-      date_operation: new Date(data.date_operation)
-    };
+      ...result,
+      date_operation: new Date(op_date)
+    } as Operation;
   }
 
   async deleteOperation(id: string): Promise<void> {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,12 +1,8 @@
-import { createClient } from '@supabase/supabase-js';
+import { supabase, isSupabaseEnabled } from '../contexts/AuthContext';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// Re-export the shared Supabase client instantiated in AuthContext.
+export { supabase };
 
-export const supabase = supabaseUrl && supabaseAnonKey 
-  ? createClient(supabaseUrl, supabaseAnonKey)
-  : null;
+// Helper used by the repository factory to know if Supabase is configured.
+export const isSupabaseAvailable = () => isSupabaseEnabled;
 
-export const isSupabaseAvailable = () => {
-  return supabase !== null;
-};


### PR DESCRIPTION
## Summary
- query `operations` using `op_date` and map to `date_operation`
- centralize Supabase client through AuthContext
- remove nested router/AuthProvider in `App.tsx`

## Testing
- `npm run lint` *(fails: unused vars and unexpected any in existing files)*
- `npm run build` *(fails: TS2339: Property 'profile' does not exist on type 'AuthContextValue')*

------
https://chatgpt.com/codex/tasks/task_e_68ae6a1749488322816f7d09de59dd59