### PR TITLE
feat: expose user profile in auth context

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,14 @@ export type OperationType = 'achat' | 'vente';
 export type MouvementType = 'entree' | 'sortie' | 'transfert' | 'ajustement';
 export type ModeValorisationType = 'FIFO' | 'MOYEN_PONDERE';
 
+// Table profiles (utilisateurs)
+export interface Profile {
+  id: string;
+  email: string;
+  full_name?: string;
+  role: 'admin' | 'user';
+}
+
 // Table operations
 export interface Operation {
   id: string;


### PR DESCRIPTION
## Summary
- add Profile type and fetch from Supabase
- expose profile state in AuthContext

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 94 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae6c1b68ac832291bb0f46d200eea2