### PR TITLE
Allow dynamic host in Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,12 +8,7 @@ export default defineConfig({
     host: '0.0.0.0',
     port: 3000,
     strictPort: true,
-    allowedHosts: [
-      '3000-icmsarcraz9y3bljxdtx8-6532622b.e2b.dev',
-      'localhost',
-      '127.0.0.1',
-      '0.0.0.0'
-    ],
+    allowedHosts: process.env.HOST ? [process.env.HOST] : true,
     cors: true,
     hmr: {
       clientPort: 3000


### PR DESCRIPTION
## Summary
- allow Vite dev server to accept the current HOST env or any host

## Testing
- `npm run lint` *(fails: no-unused-vars, react-refresh, etc.)*
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68af71e6e9dc8322a5674c08fa6ecbdd