### PR TITLE
chore: skip seed in production

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,9 +28,9 @@ function AppContent() {
         // Initialiser le repository
         await repository.init()
         
-        // Charger les données de seed si c'est la première fois
+        // Charger les données de seed si c'est la première fois (dev uniquement)
         const operations = await repository.getOperations()
-        if (operations.length === 0) {
+        if (operations.length === 0 && process.env.NODE_ENV !== 'production') {
           console.log('🌱 Chargement des données de démonstration...')
           await repository.seedData()
           console.log('✅ Données de démonstration chargées')


### PR DESCRIPTION
## Summary
- guard demo seed logic to run only outside production

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: many lint errors)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1bf7479ec8322ad9a876fa0e69c54